### PR TITLE
Generate index and tags json on push

### DIFF
--- a/.github/workflows/generate-json.yml
+++ b/.github/workflows/generate-json.yml
@@ -1,0 +1,35 @@
+name: Generate JSON Files
+
+on:
+  push:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  generate-json:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        
+    - name: Install dependencies
+      run: |
+        npm init -y
+        npm install --save-dev js-yaml
+        
+    - name: Generate JSON files
+      run: node scripts/generate-json.js
+      
+    - name: Commit and push if changed
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add index.json tags.json
+        git diff --staged --quiet || git commit -m "Auto-update: Generate index.json and tags.json"
+        git push

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 !.gitignore
 !Article/
 !Article/**/*
+!.github/
+!.github/**/*
+!scripts/
+!scripts/**/*
+!index.json
+!tags.json
+!README.md

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 ### `tags.json`  
 - 使用されているタグの一覧
 - 各タグの使用回数
+- 各タグに紐づく記事の詳細情報（id, title, excerpt, publishedAt, path）
 - 使用回数の多い順にソート
 
 ## 記事の書き方

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Notes Repository
+
+このリポジトリは記事の自動インデックス生成機能を持つノートリポジトリです。
+
+## 自動生成ファイル
+
+プッシュ時に以下のJSONファイルが自動生成されます：
+
+### `index.json`
+- 全記事の一覧情報
+- 記事のメタデータ（タイトル、タグ、作成日、ID等）
+- 記事の抜粋テキスト
+- 公開日の新しい順にソート
+
+### `tags.json`  
+- 使用されているタグの一覧
+- 各タグの使用回数
+- 使用回数の多い順にソート
+
+## 記事の書き方
+
+`Article/` ディレクトリに以下の形式でMarkdownファイルを配置してください：
+
+```markdown
+---
+tags: [Git, TECH, 駆け出しエンジニア応援]
+createdAt: 2025-01-02 00:00
+publishedAt: 2025-01-02
+id: 7hltyl68nznj
+---
+
+# 記事タイトル
+
+記事の内容...
+```
+
+### フロントマター（必須）
+- `tags`: タグの配列
+- `createdAt`: 作成日時
+- `publishedAt`: 公開日時  
+- `id`: 記事の一意ID
+
+## GitHub Actions
+
+`.github/workflows/generate-json.yml` により、main/masterブランチへのプッシュ時に自動実行されます：
+
+1. Node.js環境のセットアップ
+2. 依存関係のインストール（js-yaml）
+3. `scripts/generate-json.js`の実行
+4. 生成されたJSONファイルのコミット・プッシュ

--- a/scripts/generate-json.js
+++ b/scripts/generate-json.js
@@ -1,0 +1,154 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ARTICLE_DIR = 'Article';
+const INDEX_FILE = 'index.json';
+const TAGS_FILE = 'tags.json';
+
+// Function to extract frontmatter from markdown content
+function extractFrontmatter(content) {
+  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---/;
+  const match = content.match(frontmatterRegex);
+  
+  if (!match) {
+    return null;
+  }
+  
+  try {
+    return yaml.load(match[1]);
+  } catch (error) {
+    console.error('Error parsing YAML frontmatter:', error);
+    return null;
+  }
+}
+
+// Function to extract title from filename or content
+function extractTitle(filename, content) {
+  // Try to extract from filename (remove date prefix and extension)
+  const titleFromFilename = filename
+    .replace(/^\d{4}-\d{2}-\d{2}_/, '') // Remove date prefix
+    .replace(/\.md$/, ''); // Remove .md extension
+  
+  // Try to extract from first heading in content
+  const headingMatch = content.match(/^#\s+(.+)$/m);
+  if (headingMatch) {
+    return headingMatch[1].trim();
+  }
+  
+  return titleFromFilename;
+}
+
+// Function to extract excerpt from content
+function extractExcerpt(content, maxLength = 200) {
+  // Remove frontmatter
+  const contentWithoutFrontmatter = content.replace(/^---\s*\n[\s\S]*?\n---\s*\n/, '');
+  
+  // Remove markdown syntax and get plain text
+  const plainText = contentWithoutFrontmatter
+    .replace(/!\[\[.*?\]\]/g, '') // Remove image links
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // Replace links with text
+    .replace(/[#*`_~]/g, '') // Remove markdown formatting
+    .replace(/\n+/g, ' ') // Replace newlines with spaces
+    .trim();
+  
+  if (plainText.length <= maxLength) {
+    return plainText;
+  }
+  
+  return plainText.substring(0, maxLength).trim() + '...';
+}
+
+// Main function to process articles and generate JSON files
+function generateJsonFiles() {
+  if (!fs.existsSync(ARTICLE_DIR)) {
+    console.error(`Article directory '${ARTICLE_DIR}' not found`);
+    return;
+  }
+  
+  const articles = [];
+  const tagsCount = {};
+  
+  // Read all markdown files from Article directory
+  const files = fs.readdirSync(ARTICLE_DIR)
+    .filter(file => file.endsWith('.md') && file !== 'README.md');
+  
+  files.forEach(filename => {
+    const filepath = path.join(ARTICLE_DIR, filename);
+    const content = fs.readFileSync(filepath, 'utf-8');
+    const frontmatter = extractFrontmatter(content);
+    
+    if (!frontmatter) {
+      console.warn(`No frontmatter found in ${filename}`);
+      return;
+    }
+    
+    const title = extractTitle(filename, content);
+    const excerpt = extractExcerpt(content);
+    
+    const article = {
+      id: frontmatter.id || filename.replace(/\.md$/, ''),
+      title: title,
+      excerpt: excerpt,
+      tags: frontmatter.tags || [],
+      createdAt: frontmatter.createdAt || frontmatter.publishedAt || null,
+      publishedAt: frontmatter.publishedAt || frontmatter.createdAt || null,
+      filename: filename,
+      path: `Article/${filename}`
+    };
+    
+    articles.push(article);
+    
+    // Count tags
+    if (frontmatter.tags && Array.isArray(frontmatter.tags)) {
+      frontmatter.tags.forEach(tag => {
+        tagsCount[tag] = (tagsCount[tag] || 0) + 1;
+      });
+    }
+  });
+  
+  // Sort articles by publishedAt (newest first)
+  articles.sort((a, b) => {
+    if (!a.publishedAt && !b.publishedAt) return 0;
+    if (!a.publishedAt) return 1;
+    if (!b.publishedAt) return -1;
+    return new Date(b.publishedAt) - new Date(a.publishedAt);
+  });
+  
+  // Generate index.json
+  const indexData = {
+    articles: articles,
+    totalCount: articles.length,
+    lastUpdated: new Date().toISOString()
+  };
+  
+  // Generate tags.json
+  const tagsData = {
+    tags: Object.entries(tagsCount)
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count), // Sort by count (descending)
+    totalTags: Object.keys(tagsCount).length,
+    lastUpdated: new Date().toISOString()
+  };
+  
+  // Write files
+  fs.writeFileSync(INDEX_FILE, JSON.stringify(indexData, null, 2));
+  fs.writeFileSync(TAGS_FILE, JSON.stringify(tagsData, null, 2));
+  
+  console.log(`Generated ${INDEX_FILE} with ${articles.length} articles`);
+  console.log(`Generated ${TAGS_FILE} with ${Object.keys(tagsCount).length} tags`);
+  
+  // Log summary
+  console.log('\nArticles processed:');
+  articles.forEach(article => {
+    console.log(`- ${article.title} (${article.tags.join(', ')})`);
+  });
+  
+  console.log('\nTags found:');
+  Object.entries(tagsCount).forEach(([tag, count]) => {
+    console.log(`- ${tag}: ${count} article(s)`);
+  });
+}
+
+// Run the script
+generateJsonFiles();

--- a/scripts/generate-json.js
+++ b/scripts/generate-json.js
@@ -122,10 +122,34 @@ function generateJsonFiles() {
     lastUpdated: new Date().toISOString()
   };
   
-  // Generate tags.json
+  // Generate tags.json with articles
+  const tagsWithArticles = {};
+  
+  // Group articles by tags
+  articles.forEach(article => {
+    if (article.tags && Array.isArray(article.tags)) {
+      article.tags.forEach(tag => {
+        if (!tagsWithArticles[tag]) {
+          tagsWithArticles[tag] = [];
+        }
+        tagsWithArticles[tag].push({
+          id: article.id,
+          title: article.title,
+          excerpt: article.excerpt,
+          publishedAt: article.publishedAt,
+          path: article.path
+        });
+      });
+    }
+  });
+  
   const tagsData = {
     tags: Object.entries(tagsCount)
-      .map(([name, count]) => ({ name, count }))
+      .map(([name, count]) => ({
+        name,
+        count,
+        articles: tagsWithArticles[name] || []
+      }))
       .sort((a, b) => b.count - a.count), // Sort by count (descending)
     totalTags: Object.keys(tagsCount).length,
     lastUpdated: new Date().toISOString()


### PR DESCRIPTION
Add GitHub Actions to generate `index.json` and `tags.json` from markdown articles.

This PR introduces a GitHub Actions workflow that automatically parses markdown files in the `Article/` directory on every push, extracting metadata to generate `index.json` (for article listings) and `tags.json` (for tag information). This enables easy consumption of article data by a frontend application.

---

[Open in Web](https://cursor.com/agents?id=bc-1e10b6d8-7fdc-4ffd-9fa6-d70c23943dde) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1e10b6d8-7fdc-4ffd-9fa6-d70c23943dde) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)